### PR TITLE
Add cheekpoint nodes to each level and store the latest state for the user. 

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -81,6 +81,10 @@ inhabit={
 ]
 }
 
+[layer_names]
+
+2d_physics/layer_3="Cheekpoint"
+
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0

--- a/scenes/components/core/cheekpoint/CheekpointManager.tscn
+++ b/scenes/components/core/cheekpoint/CheekpointManager.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://by2qpmdskkvp6"]
+
+[ext_resource type="Script" path="res://scenes/components/core/cheekpoint/cheekpoint_manager.gd" id="1_abh12"]
+
+[node name="CheekpointManager" type="Node"]
+script = ExtResource("1_abh12")

--- a/scenes/components/core/cheekpoint/cheekpoint.gd
+++ b/scenes/components/core/cheekpoint/cheekpoint.gd
@@ -1,0 +1,15 @@
+extends Node2D
+class_name Cheekpoint
+
+signal cheekpoint_entered(id: int, position: Vector2)
+
+@export var cp_id: int
+
+var is_active = false
+
+# Only the player area_2d exists on the cheekpoint layer so this
+# should only interact with that object
+func _on_area_2d_area_entered(area):
+	if not is_active:
+		cheekpoint_entered.emit(cp_id, position)
+		is_active = true

--- a/scenes/components/core/cheekpoint/cheekpoint.tscn
+++ b/scenes/components/core/cheekpoint/cheekpoint.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=3 uid="uid://d4n14h508n7q0"]
+
+[ext_resource type="Script" path="res://scenes/components/core/cheekpoint/cheekpoint.gd" id="1_2melb"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_bkjno"]
+radius = 100.0
+
+[node name="Cheekpoint" type="Node2D"]
+script = ExtResource("1_2melb")
+
+[node name="Area2D" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 4
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+shape = SubResource("CircleShape2D_bkjno")
+
+[connection signal="area_entered" from="Area2D" to="." method="_on_area_2d_area_entered"]

--- a/scenes/components/core/cheekpoint/cheekpoint_manager.gd
+++ b/scenes/components/core/cheekpoint/cheekpoint_manager.gd
@@ -1,0 +1,62 @@
+extends Node
+
+@export var level_name: String
+@export var player_node: Node2D
+
+const CHEEKPOINT_FILE: String = "user://cheekpoint.dat"
+
+var id_key: String 
+var position_x_key: String 
+var position_y_key: String 
+
+var cheekpoint_dict = {}
+
+func _ready():
+	id_key = str(level_name, "_id")
+	position_x_key = str(level_name, "_position_x")
+	position_y_key = str(level_name, "_position_y")
+	
+	load_cheekpoint_state()
+	if player_node != null and cheekpoint_dict.has(position_x_key):
+		var x = cheekpoint_dict[position_x_key] as int
+		var y = cheekpoint_dict[position_y_key] as int
+		player_node.position = Vector2(x, y)
+		
+	for child in get_children():
+		if child is Cheekpoint:
+			child.cheekpoint_entered.connect(on_cheekpoint_entered)
+			
+
+func _exit_tree():
+	save_cheekpoint_state()
+
+
+func on_cheekpoint_entered(id: int, position: Vector2):
+	if not cheekpoint_dict.has(id_key) or cheekpoint_dict[id_key] < id:
+		cheekpoint_dict[position_x_key] = position.x
+		cheekpoint_dict[position_y_key] = position.y
+		cheekpoint_dict[id_key] = id
+
+
+func save_cheekpoint_state():
+	var file = FileAccess.open(CHEEKPOINT_FILE, FileAccess.WRITE)
+	var json_str = JSON.stringify(cheekpoint_dict)
+	file.store_line(json_str)
+	file.close()
+
+
+func load_cheekpoint_state():
+	var file = FileAccess.open(CHEEKPOINT_FILE, FileAccess.READ)
+	if not file or file == null:
+		return
+	if not FileAccess.file_exists(CHEEKPOINT_FILE):
+		return
+#
+	cheekpoint_dict = JSON.parse_string(file.get_line())
+	file.close()
+
+
+func _on_level_goal_level_complete():
+	cheekpoint_dict.erase(id_key)
+	cheekpoint_dict.erase(position_x_key)
+	cheekpoint_dict.erase(position_y_key)

--- a/scenes/components/level_objects/level_goal.gd
+++ b/scenes/components/level_objects/level_goal.gd
@@ -1,5 +1,7 @@
 extends Area2D
 
+signal level_complete()
+
 const GOAL_BOX_POSITION: Vector2 = Vector2(960, 540)
 @onready var animated_sprite_2d: AnimatedSprite2D = $AnimatedSprite2D
 @onready var label: Label = $Label
@@ -22,6 +24,7 @@ func _on_body_entered(body):
 		label.visible = false
 		get_tree().paused = true
 		TimeTrialController.store_level_time()
+		level_complete.emit()
 		animated_sprite_2d.play("level complete")
 
 

--- a/scenes/components/player/player_node.tscn
+++ b/scenes/components/player/player_node.tscn
@@ -87,6 +87,7 @@ frame_progress = 0.518968
 shape = SubResource("CapsuleShape2D_iayn0")
 
 [node name="Area2D" type="Area2D" parent="."]
+collision_layer = 5
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 shape = SubResource("CircleShape2D_5d42r")

--- a/scenes/levels/l1_graveyard.tscn
+++ b/scenes/levels/l1_graveyard.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=3 uid="uid://dbjqo72ufu8il"]
+[gd_scene load_steps=20 format=3 uid="uid://dbjqo72ufu8il"]
 
 [ext_resource type="Script" path="res://scenes/levels/l1_graveyard.gd" id="1_ima00"]
 [ext_resource type="PackedScene" uid="uid://16qibkk2s8nj" path="res://scenes/components/player/player_node.tscn" id="2_rxa3n"]
@@ -15,6 +15,8 @@
 [ext_resource type="PackedScene" uid="uid://bcdwfjuq08d4g" path="res://scenes/components/level_objects/graveyard/shovel.tscn" id="11_0435a"]
 [ext_resource type="PackedScene" uid="uid://bp0v45ivh8jn5" path="res://scenes/components/level_objects/graveyard/skull.tscn" id="12_5kwlk"]
 [ext_resource type="PackedScene" uid="uid://cxyifp4hqr5gd" path="res://scenes/components/level_objects/pulley/pulley.tscn" id="14_xvi6o"]
+[ext_resource type="PackedScene" uid="uid://by2qpmdskkvp6" path="res://scenes/components/core/cheekpoint/CheekpointManager.tscn" id="16_m3rpw"]
+[ext_resource type="PackedScene" uid="uid://d4n14h508n7q0" path="res://scenes/components/core/cheekpoint/cheekpoint.tscn" id="16_qpyfg"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_tos1s"]
 atlas = ExtResource("7_ifd2e")
@@ -97,3 +99,17 @@ position = Vector2(8345, -1149)
 
 [node name="Pulley" parent="Props" instance=ExtResource("14_xvi6o")]
 position = Vector2(8012, -1033)
+
+[node name="CheekpointManager" parent="." node_paths=PackedStringArray("player_node") instance=ExtResource("16_m3rpw")]
+level_name = "graveyard"
+player_node = NodePath("../PlayerNode")
+
+[node name="Cheekpoint" parent="CheekpointManager" instance=ExtResource("16_qpyfg")]
+position = Vector2(1964, -1354)
+cp_id = 1
+
+[node name="Cheekpoint2" parent="CheekpointManager" instance=ExtResource("16_qpyfg")]
+position = Vector2(5666, -1244)
+cp_id = 2
+
+[connection signal="level_complete" from="LevelExitDoor/LevelGoal" to="CheekpointManager" method="_on_level_goal_level_complete"]

--- a/scenes/levels/l2_sewer.tscn
+++ b/scenes/levels/l2_sewer.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://0yqbnvklhx3c"]
+[gd_scene load_steps=19 format=3 uid="uid://0yqbnvklhx3c"]
 
 [ext_resource type="Script" path="res://scenes/levels/l2_sewer.gd" id="1_xilwi"]
 [ext_resource type="PackedScene" uid="uid://16qibkk2s8nj" path="res://scenes/components/player/player_node.tscn" id="2_wv6yu"]
@@ -15,6 +15,8 @@
 [ext_resource type="PackedScene" uid="uid://div4i8mqaycqn" path="res://scenes/components/level_objects/sewer/pipe.tscn" id="9_pckph"]
 [ext_resource type="PackedScene" uid="uid://mlo68p4bwg3p" path="res://scenes/components/level_objects/sewer/tire.tscn" id="10_5njos"]
 [ext_resource type="PackedScene" uid="uid://r2nrmb5lhihl" path="res://scenes/components/level_objects/sewer/trash.tscn" id="11_oqdtk"]
+[ext_resource type="PackedScene" uid="uid://by2qpmdskkvp6" path="res://scenes/components/core/cheekpoint/CheekpointManager.tscn" id="16_18d2e"]
+[ext_resource type="PackedScene" uid="uid://d4n14h508n7q0" path="res://scenes/components/core/cheekpoint/cheekpoint.tscn" id="17_yccks"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_qrwpc"]
 atlas = ExtResource("7_pduhy")
@@ -182,3 +184,17 @@ rotation = 0.55676
 [node name="Trash11" parent="Props/Section5" instance=ExtResource("11_oqdtk")]
 position = Vector2(12757, -2934)
 rotation = 0.778417
+
+[node name="CheekpointManager" parent="." node_paths=PackedStringArray("player_node") instance=ExtResource("16_18d2e")]
+level_name = "sewer"
+player_node = NodePath("../PlayerNode")
+
+[node name="Cheekpoint" parent="CheekpointManager" instance=ExtResource("17_yccks")]
+position = Vector2(3932, -996)
+cp_id = 1
+
+[node name="Cheekpoint2" parent="CheekpointManager" instance=ExtResource("17_yccks")]
+position = Vector2(8692, -1844)
+cp_id = 2
+
+[connection signal="level_complete" from="LevelExitDoor/LevelGoal" to="CheekpointManager" method="_on_level_goal_level_complete"]

--- a/scenes/levels/l3_cave.tscn
+++ b/scenes/levels/l3_cave.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://r4804veh7o4m"]
+[gd_scene load_steps=19 format=3 uid="uid://r4804veh7o4m"]
 
 [ext_resource type="Script" path="res://scenes/levels/l3_cave.gd" id="1_ubl5i"]
 [ext_resource type="PackedScene" uid="uid://16qibkk2s8nj" path="res://scenes/components/player/player_node.tscn" id="2_gxems"]
@@ -15,6 +15,8 @@
 [ext_resource type="PackedScene" uid="uid://8ep2744llxxx" path="res://scenes/components/level_objects/cave/stone.tscn" id="9_udnu8"]
 [ext_resource type="PackedScene" uid="uid://ci7qb7t4ewfwe" path="res://scenes/components/level_objects/cave/stone_block.tscn" id="10_2ahja"]
 [ext_resource type="PackedScene" uid="uid://cxyifp4hqr5gd" path="res://scenes/components/level_objects/pulley/pulley.tscn" id="11_mqa5f"]
+[ext_resource type="PackedScene" uid="uid://by2qpmdskkvp6" path="res://scenes/components/core/cheekpoint/CheekpointManager.tscn" id="16_4jhpn"]
+[ext_resource type="PackedScene" uid="uid://d4n14h508n7q0" path="res://scenes/components/core/cheekpoint/cheekpoint.tscn" id="17_xsgcb"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_dms41"]
 atlas = ExtResource("7_peb1j")
@@ -66,6 +68,7 @@ position = Vector2(1121, -3005)
 
 [node name="Boulder" parent="Props" instance=ExtResource("5_y2mh2")]
 position = Vector2(1401, -2348)
+mass = 5.0
 
 [node name="StoneBlock4" parent="Props" instance=ExtResource("10_2ahja")]
 position = Vector2(95, -1849)
@@ -126,3 +129,17 @@ position = Vector2(8214, -2735)
 [node name="Crystal4" parent="Props" instance=ExtResource("7_os3w6")]
 position = Vector2(2160, -2935)
 rotation = 0.420624
+
+[node name="CheekpointManager" parent="." node_paths=PackedStringArray("player_node") instance=ExtResource("16_4jhpn")]
+level_name = "cave"
+player_node = NodePath("../PlayerNode")
+
+[node name="Cheekpoint" parent="CheekpointManager" instance=ExtResource("17_xsgcb")]
+position = Vector2(3606, -1658)
+cp_id = 1
+
+[node name="Cheekpoint2" parent="CheekpointManager" instance=ExtResource("17_xsgcb")]
+position = Vector2(4848, -3182)
+cp_id = 2
+
+[connection signal="level_complete" from="LevelExitDoor/LevelGoal" to="CheekpointManager" method="_on_level_goal_level_complete"]


### PR DESCRIPTION
Add `Cheekpoint` component which registers when the player passes through and emits a signal. 
Add `CheekpointManager` which updates a local dict when capturing a cheekpoint signal and reads/writes to local storage. 

Note, this currently messes up time trial results. Another PR incoming to ignore cheekpoints when time trial is active. 